### PR TITLE
[bugfix] 한국어 조사처리 모듈 사용하여 은/는 와/과 같은 조사를 처리함

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@types/react": "17.0.0",
     "@types/react-dom": "17.0.0",
     "axios": "0.21.1",
+    "cox-postposition": "^1.4.1",
     "dotenv": "^8.2.0",
     "node-sass": "^4.0.0",
     "query-string": "^6.14.0",

--- a/frontend/src/components/PlantsDetail/Feature.jsx
+++ b/frontend/src/components/PlantsDetail/Feature.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import {pick} from 'cox-postposition';
 import Section, {SIDE} from '../Section';
 import SubHead from '../../styles/SubHead';
 import FeatureCard from './FeatureCard';
@@ -14,7 +15,7 @@ function Feature({name = '', feature = ''}) {
     <Section width="lg" margin={100} bgColor="lightGray" order={SIDE}>
       <div>
         <TagsHead>
-          <span>{name}</span>는 이런 반전 매력도 있어요
+          <span>{name}</span>{pick(name, '는')} 이런 반전 매력도 있어요
         </TagsHead>
         <Features>
           {features.map((feature, i) => (

--- a/frontend/src/components/PlantsDetail/Friends.jsx
+++ b/frontend/src/components/PlantsDetail/Friends.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {pick} from 'cox-postposition'
 import Section, {SIDE} from '../Section';
 import {TagsHead} from './Feature';
 import Slider from '../Slider';
@@ -27,7 +28,7 @@ function Friends({name = '', plants}) {
   return (
     <Section margin={100} width="lg" order={SIDE}>
       <TagsHead>
-        <span>{name}</span>와 비슷한 친구 추천
+        <span>{name}</span>{pick(name, '와')} 비슷한 친구 추천
       </TagsHead>
       <Slider plants={plants} />
     </Section>

--- a/frontend/src/components/PlantsDetail/TagsDetail.jsx
+++ b/frontend/src/components/PlantsDetail/TagsDetail.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Grid from '@material-ui/core/Grid';
+import {pick} from 'cox-postposition';
 
 import Section from '../Section';
 import {TagsHead} from './Feature';
@@ -32,7 +33,7 @@ function TagsDetail({name = '', tags = []}) {
     <Section width="lg" margin={100}>
       <div>
         <DetailsHead>
-          <span>{name}</span>는 어떤 친구인가요?
+          <span>{name}</span>{pick(name, '는')} 어떤 친구인가요?
         </DetailsHead>
         <Grid container spacing={matches ? 2 : 3}>
           {tags.map(

--- a/frontend/src/components/PlantsDetail/Warning.jsx
+++ b/frontend/src/components/PlantsDetail/Warning.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
+import {pick} from 'cox-postposition';
 
 import Section from '../Section';
 import WarningCard from './WarningCard';
 import {TagsHead} from './Feature';
+
 
 /* 
 name: string
@@ -16,7 +18,7 @@ function Warning({name = '', warning = ''}) {
     <div>
       <Section width="lg" margin={100} bgColor="lightGray">
         <WarningHead>
-          <span>{name}</span>를 대할 때 주의할 점은?
+          <span>{name}</span>{pick(name, '를')} 대할 때 주의할 점은?
         </WarningHead>
         <Warnings>
           {warnings.map((warning, i) => (

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3793,6 +3793,11 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cox-postposition@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/cox-postposition/-/cox-postposition-1.4.1.tgz#658b6e7dda6707e9e6db1c45fc47514cfd638e0f"
+  integrity sha512-TNXGxd7l49ogBp0VMVDHhId2wk2NTpzcR2xg+rjHzB25YSs91gEDko0WmV9xPNLZzPnqdeBcrVHbHJzo3EfnNQ==
+
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz"


### PR DESCRIPTION
## AS-IS 

<img width="1080" alt="스크린샷 2021-02-28 오후 10 56 38" src="https://user-images.githubusercontent.com/59886140/109420896-3f049200-7a18-11eb-94a3-f3c956da8d2b.png">

## TO-BE

<img width="1080" alt="스크린샷 2021-02-28 오후 10 56 24" src="https://user-images.githubusercontent.com/59886140/109420899-42981900-7a18-11eb-9314-869dde6bb5da.png">

ref : https://github.com/coxcore/postposition

부자연스러운 조사를 처리하기 위해 한국어 조사처리 모듈 추가 및 대응했습니다..

신경쓰여서 😄